### PR TITLE
Update pkg dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/go-playground/backoff-sys v1.1.1
 	github.com/go-playground/errors/v5 v5.1.1
-	github.com/go-playground/pkg/v5 v5.5.0
+	github.com/go-playground/pkg/v5 v5.6.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/go-playground/form/v4 v4.1.1/go.mod h1:q1a2BY+AQUUzhl6xA/6hBetay6dEIh
 github.com/go-playground/form/v4 v4.2.0 h1:N1wh+Goz61e6w66vo8vJkQt+uwZSoLz50kZPJWR8eic=
 github.com/go-playground/form/v4 v4.2.0/go.mod h1:q1a2BY+AQUUzhl6xA/6hBetay6dEIhMHjgvJiGo6K7U=
 github.com/go-playground/pkg/v5 v5.0.0/go.mod h1:0380E0lsFB1POWFypOLL8tX2f0O1OBCBpSdVmEy4mg0=
-github.com/go-playground/pkg/v5 v5.5.0 h1:I+2yXV/GSH4MB/s2RXIlRnWZZdSgttS+MnAH4yRt8sE=
-github.com/go-playground/pkg/v5 v5.5.0/go.mod h1:TvZ2nNtNh6VfoNteY9ApA2BXt1ZwJliFZ4hzPAwLS9Y=
+github.com/go-playground/pkg/v5 v5.6.0 h1:97YpRFzIcS5NFP2Uzxj8cPYz4zTuwweyXADYcA1KfUQ=
+github.com/go-playground/pkg/v5 v5.6.0/go.mod h1:TvZ2nNtNh6VfoNteY9ApA2BXt1ZwJliFZ4hzPAwLS9Y=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Updated github.com/go-playground/pkg -> v5.6.0 which contains additions
to retry HTTP 408 requests.